### PR TITLE
Make script usable from other directories

### DIFF
--- a/bin/gen-graphs.sh
+++ b/bin/gen-graphs.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
-cat perf-recorded.data | _node --cache lib/collapse  > perf-collapsed.data
+
+BASE_PATH="$(dirname $0)/.."
+
+cat perf-recorded.data | _node --cache "$BASE_PATH/lib/collapse"  > perf-collapsed.data
 [ -f palette.map ] || echo "io->rgb(0,255,255)" > palette.map
-cat perf-collapsed.data | ./deps/flamegraph.pl --cp $* > perf-full.svg
-cat perf-collapsed.data | egrep -v -e ';io \d+$' | ./deps/flamegraph.pl --cp $* > perf-cpu.svg
+cat perf-collapsed.data | "$BASE_PATH/deps/flamegraph.pl" --cp $* > perf-full.svg
+cat perf-collapsed.data | egrep -v -e ';io \d+$' | "$BASE_PATH/deps/flamegraph.pl" --cp $* > perf-cpu.svg


### PR DESCRIPTION
E.g. the directory where the data files actually live.

Previously, the script required you to be in the `streamline-flamegraph` module.
